### PR TITLE
Improve recipe parsing and share recipes as Markdown

### DIFF
--- a/Cookbook/Views/RecipeDetailView.swift
+++ b/Cookbook/Views/RecipeDetailView.swift
@@ -478,16 +478,14 @@ struct RecipeDetailView: View {
     }
 
     private func shareRecipe() {
-        // Create temporary file with .cookbook.json extension
+        // Create temporary Markdown file for sharing
         let tempDir = FileManager.default.temporaryDirectory
-        let fileName = "\(recipe.title.replacingOccurrences(of: " ", with: "_")).cookbook.json"
+        let fileName = "\(recipe.title.replacingOccurrences(of: " ", with: "_")).md"
         let fileURL = tempDir.appendingPathComponent(fileName)
 
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(recipe)
-            try data.write(to: fileURL)
+            let markdown = RecipeMarkdownSerializer.serialize(recipe)
+            try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
 
             // Present share sheet
             #if os(iOS)

--- a/Cookbook/Views/RecipeListView.swift
+++ b/Cookbook/Views/RecipeListView.swift
@@ -433,16 +433,14 @@ struct RecipeListView: View {
     }
     
     private func shareRecipe(_ recipe: Recipe) {
-        // Create temporary file
+        // Create temporary Markdown file for sharing
         let tempDir = FileManager.default.temporaryDirectory
-        let fileName = "\(recipe.title.replacingOccurrences(of: " ", with: "_")).cookbook.json"
+        let fileName = "\(recipe.title.replacingOccurrences(of: " ", with: "_")).md"
         let fileURL = tempDir.appendingPathComponent(fileName)
-        
+
         do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = .prettyPrinted
-            let data = try encoder.encode(recipe)
-            try data.write(to: fileURL)
+            let markdown = RecipeMarkdownSerializer.serialize(recipe)
+            try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
             
             // Present share sheet
             #if os(iOS)


### PR DESCRIPTION
## Summary
This PR improves recipe URL importing and changes the recipe sharing format from JSON to Markdown for better user experience.

## Key Changes

- **Enhanced recipe instruction parsing**: Refactored the instruction parsing logic in `RecipeURLImporter` to properly handle nested `HowToSection` structures and multiple instruction formats. The parser now:
  - Detects and flattens `HowToSection` items containing nested `HowToStep` elements
  - Falls back to `text` and `name` fields when available
  - Filters out empty strings to avoid blank steps
  - Handles multiple instruction structure variations more robustly

- **Changed recipe sharing format**: Updated both `RecipeListView` and `RecipeDetailView` to share recipes as Markdown files instead of JSON:
  - File extension changed from `.cookbook.json` to `.md`
  - Implemented `RecipeMarkdownSerializer` for converting recipes to human-readable Markdown format
  - Improved user experience when sharing recipes with other applications

## Implementation Details

The instruction parsing now uses a loop-based approach instead of `compactMap`, allowing for more complex conditional logic to handle different Schema.org recipe structures. The sharing functionality now leverages a dedicated serializer for consistent Markdown formatting across the app.

https://claude.ai/code/session_016fgMCDEsLwr557GcxPvtJo