### PR TITLE
Initialize empty ingredient section for new recipes

### DIFF
--- a/Cookbook/Views/RecipeEditView.swift
+++ b/Cookbook/Views/RecipeEditView.swift
@@ -16,9 +16,13 @@ struct RecipeEditView: View {
     @State private var scrollToSectionID: UUID?
 
     init(recipe: Recipe) {
-        _recipe = State(initialValue: recipe)
+        var editableRecipe = recipe
+        if recipe.title.isEmpty && recipe.ingredientSections.isEmpty {
+            editableRecipe.ingredientSections = [IngredientSection(name: "", ingredients: [])]
+        }
+        _recipe = State(initialValue: editableRecipe)
         _isNewRecipe = State(initialValue: recipe.title.isEmpty)
-        _originalRecipe = State(initialValue: recipe)
+        _originalRecipe = State(initialValue: editableRecipe)
     }
 
     private var hasUnsavedChanges: Bool {


### PR DESCRIPTION
## Summary
Updated the `RecipeEditView` initializer to automatically create an empty ingredient section when a new recipe is created, improving the user experience by providing a starting point for adding ingredients.

## Key Changes
- Modified the `init(recipe:)` method to detect new recipes (those with empty title and no ingredient sections)
- Automatically initialize a new recipe with one empty `IngredientSection` to provide a default structure
- Applied this initialization to both the working `_recipe` state and the `_originalRecipe` state for consistency

## Implementation Details
The change ensures that when users create a new recipe, they immediately have an ingredient section ready to populate, rather than starting with a completely empty state. This reduces the friction of the initial setup process and makes the UI more intuitive for new recipe creation workflows.

https://claude.ai/code/session_0148gGujybWhfkuo6bnNLqAJ